### PR TITLE
container configs for ecs staging, +api-only, various

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+*/node_modules
+.vscode
+.git

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ docker network create --driver bridge use-custom-bridge-ok
 ##### get/run [postgres image](https://hub.docker.com/_/postgres/)/container: 
 ```bash
 docker pull postgres
-docker run -d --name postgres-container-ok --net use-custom-bridge-ok postgres
+docker run --name postgres-container-ok --net use-custom-bridge-ok -e POSTGRES_PASSWORD=postgres-ok -d postgres
+
 ```
 
 ##### psql to configure postgres db for strapi
@@ -59,8 +60,8 @@ docker run -it --rm --net use-custom-bridge-ok postgres psql -h postgres-contain
 ```
 ```psql
 CREATE DATABASE "docker-db-ok";
-ALTER DATABASE "docker-db-ok" OWNER TO "docker-user-ok";
 CREATE USER "docker-user-ok" WITH PASSWORD 'docker-password-alright';
+ALTER DATABASE "docker-db-ok" OWNER TO "docker-user-ok";
 ALTER USER "docker-user-ok" WITH SUPERUSER;
 GRANT ALL PRIVILEGES ON DATABASE "docker-db-ok" TO "docker-user-ok";
 ```

--- a/config/environments/production/database.json
+++ b/config/environments/production/database.json
@@ -2,19 +2,18 @@
   "defaultConnection": "default",
   "connections": {
     "default": {
-      "connector": "strapi-hook-mongoose",
+      "connector": "strapi-hook-bookshelf",
       "settings": {
-        "client": "mongo",
-        "uri": "${process.env.DATABASE_URI || ''}",
+        "client": "postgres",
         "host": "${process.env.DATABASE_HOST || '127.0.0.1'}",
-        "port": "${process.env.DATABASE_PORT || 27017}",
-        "database": "${process.env.DATABASE_NAME || 'strapi-production'}",
+        "srv": false,
+        "port": "${process.env.DATABASE_PORT || 5432}",
+        "database": "${process.env.DATABASE_NAME || ''}",
         "username": "${process.env.DATABASE_USERNAME || ''}",
         "password": "${process.env.DATABASE_PASSWORD || ''}"
       },
       "options": {
-        "ssl": "${process.env.DATABASE_SSL || false}",
-        "authenticationDatabase": "${process.env.DATABASE_AUTHENTICATION_DATABASE || ''}"
+        "ssl": "${process.env.DATABASE_SSL || false}"
       }
     }
   }

--- a/config/environments/staging/database.json
+++ b/config/environments/staging/database.json
@@ -2,19 +2,18 @@
   "defaultConnection": "default",
   "connections": {
     "default": {
-      "connector": "strapi-hook-mongoose",
+      "connector": "strapi-hook-bookshelf",
       "settings": {
-        "client": "mongo",
-        "uri": "${process.env.DATABASE_URI || ''}",
+        "client": "postgres",
         "host": "${process.env.DATABASE_HOST || '127.0.0.1'}",
-        "port": "${process.env.DATABASE_PORT || 27017}",
-        "database": "${process.env.DATABASE_NAME || 'strapi-staging'}",
+        "srv": false,
+        "port": "${process.env.DATABASE_PORT || 5432}",
+        "database": "${process.env.DATABASE_NAME || ''}",
         "username": "${process.env.DATABASE_USERNAME || ''}",
         "password": "${process.env.DATABASE_PASSWORD || ''}"
       },
       "options": {
-        "ssl": "${process.env.DATABASE_SSL || false}",
-        "authenticationDatabase": "${process.env.DATABASE_AUTHENTICATION_DATABASE || ''}"
+        "ssl": "${process.env.DATABASE_SSL || false}"
       }
     }
   }

--- a/docker-api/Dockerfile
+++ b/docker-api/Dockerfile
@@ -1,0 +1,31 @@
+FROM node:alpine
+
+# TODO: bring down image size with multi stage container build?
+
+# Install pm2
+RUN npm install pm2 -g
+
+WORKDIR /app/strapi-skeleton
+
+# Bundle APP files
+COPY api api/
+COPY config config/
+COPY public public/
+COPY package.json .
+COPY package-lock.json .
+COPY server.js .
+COPY ecosystem.config.js .
+COPY favicon.ico .
+
+# Install app dependencies
+ENV NPM_CONFIG_LOGLEVEL warn
+# RUN npm install --production
+RUN npm ci --production
+
+# Expose the listening port of your app
+EXPOSE 1337
+
+# Show current folder structure in logs
+RUN ls -al -R
+
+CMD [ "pm2-runtime", "start", "ecosystem.config.js", "--only", "strapi-skeleton-dev", "--env", "localdocker" ]

--- a/docker-api/README.md
+++ b/docker-api/README.md
@@ -1,0 +1,13 @@
+# docker-api
+## build api-only image
+```
+docker build --file docker-api/Dockerfile -t strapi-image-ok:api-only .
+```
+Note, build context aka the directory this command is run in must be the project root.
+
+## run api-only container
+```
+docker run -d -p 1337:1337 --net use-custom-bridge-ok --name strapi-api-ok strapi-image-ok:api-only
+```
+
+## 

--- a/docker-staging/Dockerfile
+++ b/docker-staging/Dockerfile
@@ -1,0 +1,31 @@
+FROM node:alpine
+
+# Install pm2
+RUN npm install pm2 -g
+
+WORKDIR /app/strapi-skeleton
+
+# Bundle APP files
+COPY admin admin/
+COPY api api/
+COPY config config/
+COPY plugins plugins/
+COPY public public/
+COPY package.json .
+COPY package-lock.json .
+COPY server.js .
+COPY ecosystem.config.js .
+COPY favicon.ico .
+
+# Install app dependencies
+ENV NPM_CONFIG_LOGLEVEL warn
+# RUN npm install --production
+RUN npm ci --production
+
+# Expose the listening port of your app
+EXPOSE 1337
+
+# Show current folder structure in logs
+RUN ls -al -R
+
+CMD [ "pm2-runtime", "start", "ecosystem.config.js", "--only", "strapi-skeleton", "--env", "staging" ]

--- a/docker-staging/README.md
+++ b/docker-staging/README.md
@@ -1,0 +1,10 @@
+# staging
+## build image
+```
+docker build --file docker-staging/Dockerfile -t strapi-staging-image-ok .
+```
+
+## run container
+```
+docker run -d -p 1337:1337 --name strapi-staging-container-ok strapi-staging-image-ok
+```

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -40,7 +40,7 @@ module.exports = {
     exec_mode: 'cluster',
   },
   {
-    name: 'strapi-skeleton-prod',
+    name: 'strapi-skeleton',
     script: 'server.js',
     instances: 1,
     autorestart: true,
@@ -52,16 +52,8 @@ module.exports = {
     env_production: {
       NODE_ENV: 'production',
     },
+    exec_mode: 'cluster',
   }],
 
-  deploy : {
-    production : {
-      user : 'node',
-      host : '212.83.163.1',
-      ref  : 'origin/master',
-      repo : 'git@github.com:repo.git',
-      path : '/var/www/production',
-      'post-deploy' : 'npm install && pm2 reload ecosystem.config.js --env production'
-    }
-  }
+  deploy : {}
 };


### PR DESCRIPTION
+ fix local postgres container instructions
+ simple `COPY` omission to arrive at a minimal-ish, strapi-api-only image + readme
+ ignore `node_modules` dir's in Docker build context to decrease time spent building images
+ ecs strapi staging image + config + readme
+ env var secrets for stage/prod config