### PR TITLE
explicit and consistent env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ COPY package.json .
 COPY package-lock.json .
 COPY server.js .
 COPY ecosystem.prod.config.js .
-# COPY ecosystem.config.js . ## dev testing
 COPY favicon.ico .
 
 # Install app dependencies
@@ -31,4 +30,3 @@ EXPOSE 1337
 # RUN ls -al -R
 
 CMD [ "pm2-runtime", "start", "ecosystem.prod.config.js" ]
-# CMD [ "pm2-runtime", "start", "ecosystem.config.js", "--env", "localdocker" ] ## dev testing

--- a/Dockerfile-staging
+++ b/Dockerfile-staging
@@ -32,4 +32,3 @@ EXPOSE 1337
 # RUN ls -al -R
 
 CMD [ "pm2-runtime", "start", "ecosystem.prod.config.js" ]
-# CMD [ "pm2-runtime", "start", "ecosystem.prod.config.js", "--env", "localdocker" ] ## dev testing

--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ psql postgres -f bootsrap-db.psql
 
 #### start strapi
 
+[TODO] replace explicit local exports with `.env` file or similar?
+
+first, set db test environment variables
+
+```bash
+export DATABASE_NAME=strapi-db
+export DATABASE_USERNAME=strapi-user
+export DATABASE_PASSWORD=strapi-user-alright
+```
+
 ```bash
 pm2 start ecosystem.config.js
 ```
@@ -75,7 +85,7 @@ docker run --name postgres-ok \
   -d strapi-postgres
 ```
 
-##### optional: run canonical postgres container
+##### optional: run canonical/other postgres container
 
 ###### get image and run
 
@@ -120,6 +130,10 @@ docker run -d \
   -p 1337:1337 \
   --net strapi-db-bridge \
   --name strapi-ok \
+  -e DATABASE_HOST=postgres-ok \
+  -e DATABASE_NAME=strapi-db \
+  -e DATABASE_USERNAME=strapi-user \
+  -e DATABASE_PASSWORD=strapi-user-alright \
   strapi
 ```
 
@@ -179,10 +193,6 @@ docker run -d -p 1337:1337 --name strapi-staging-ok strapi-staging
 TODO:
 
 <!-- ## misc
-standalone, does not run because can't link up to db:
-```bash
-docker run -p 80:1337 strapi-skeleton
-```
 ```bash
 docker exec -it some-strapi pm2 log
 docker exec -it some-strapi pm2 ls

--- a/docker-postgres/Dockerfile
+++ b/docker-postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:latest
+FROM postgres:alpine
 
 WORKDIR /docker-entrypoint-initdb.d
 

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -26,19 +26,10 @@ module.exports = {
         'README.md',
         '.git',
       ],
+      exec_mode: 'cluster',
       env: {
         NODE_ENV: 'development',
-        DATABASE_HOST: '127.0.0.1',
-        DATABASE_PORT: 5432,
-        DATABASE_NAME: 'strapi-db',
-        DATABASE_USERNAME: 'strapi-user',
-        DATABASE_PASSWORD: 'strapi-user-alright',
-        DATABASE_SSL: false,
       },
-      env_localdocker: {
-        DATABASE_HOST: 'postgres-ok',
-      },
-      exec_mode: 'cluster',
     }
   ],
 

--- a/ecosystem.prod.config.js
+++ b/ecosystem.prod.config.js
@@ -9,18 +9,10 @@ module.exports = {
       autorestart: true,
       max_memory_restart: '1G',
       append_env_to_name: true,
+      exec_mode: 'cluster',
       env: {
         NODE_ENV: 'production',
       },
-      env_localdocker: {
-        DATABASE_HOST: 'postgres-ok',
-        DATABASE_PORT: 5432,
-        DATABASE_NAME: 'strapi-db',
-        DATABASE_USERNAME: 'strapi-user',
-        DATABASE_PASSWORD: 'strapi-user-alright',
-        DATABASE_SSL: false,
-      },
-      exec_mode: 'cluster',
     },
   ],
 


### PR DESCRIPTION
+ remove pm2 app env concepts; simplifies running docker and pm2 commands
+ use postgres:alpine image as base for our custom postgres; saves like 230 MB