### PR TITLE
fix: npm unsafe-perm fix before global package install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,15 @@
 FROM node:lts-alpine
 
-
+# per: https://github.com/shanedg/strapi-skeleton/issues/31
+#
+# likely related to:
+# https://bitbucket.org/site/master/issues/16334/pipelines-failing-with-could-not-get-uid
+# https://github.com/npm/npm/issues/20861
+#
+# update: also ran into this issue when moving from node:alpine to lts-alpine:
+# https://github.com/voidlinux/void-packages/issues/4147
+# and without this unsafe-perm fix, heroku builds are failing
+RUN npm config set unsafe-perm true
 
 # Install pm2
 RUN npm install pm2 -g
@@ -18,13 +27,6 @@ COPY package-lock.json .
 COPY server.js .
 COPY ecosystem.prod.config.js .
 COPY favicon.ico .
-
-# per: https://github.com/shanedg/strapi-skeleton/issues/31
-#
-# likely related to:
-# https://bitbucket.org/site/master/issues/16334/pipelines-failing-with-could-not-get-uid
-# https://github.com/npm/npm/issues/20861
-RUN npm config set unsafe-perm true
 
 # Install app dependencies
 ENV NPM_CONFIG_LOGLEVEL warn

--- a/docker-api/Dockerfile
+++ b/docker-api/Dockerfile
@@ -1,5 +1,16 @@
 FROM node:lts-alpine
 
+# per: https://github.com/shanedg/strapi-skeleton/issues/31
+#
+# likely related to:
+# https://bitbucket.org/site/master/issues/16334/pipelines-failing-with-could-not-get-uid
+# https://github.com/npm/npm/issues/20861
+#
+# update: also ran into this issue when moving from node:alpine to lts-alpine:
+# https://github.com/voidlinux/void-packages/issues/4147
+# and without this unsafe-perm fix, heroku builds are failing
+RUN npm config set unsafe-perm true
+
 # Install pm2
 RUN npm install pm2 -g
 
@@ -14,13 +25,6 @@ COPY package-lock.json .
 COPY server.js .
 COPY ecosystem.prod.config.js .
 COPY favicon.ico .
-
-# per: https://github.com/shanedg/strapi-skeleton/issues/31
-#
-# likely related to:
-# https://bitbucket.org/site/master/issues/16334/pipelines-failing-with-could-not-get-uid
-# https://github.com/npm/npm/issues/20861
-RUN npm config set unsafe-perm true
 
 # Install app dependencies
 ENV NPM_CONFIG_LOGLEVEL warn


### PR DESCRIPTION
fixes heroku build failures that began after moving from `node:alpine` to `node:alpine-lts`; might want to revisit the virtue of the alpine-lts variant or at least develop a better understanding of how the two variants differ, i.e. which node versions are they each even running and what's most stable and maintainable

but the fix here is just to move the npm unsafe-perm fix before running the first global package install; thought it could be deferred until just before the install step and avoid an "unsafe" config for more of the build but heroku isn't having it