### PR TITLE
feat: remove process manager from containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,6 @@ FROM node:lts-alpine
 # and without this unsafe-perm fix, heroku builds are failing
 RUN npm config set unsafe-perm true
 
-# Install pm2
-RUN npm install pm2 -g
-
 WORKDIR /app/strapi-skeleton
 
 # Bundle APP files
@@ -25,12 +22,12 @@ COPY public public/
 COPY package.json .
 COPY package-lock.json .
 COPY server.js .
-COPY ecosystem.prod.config.js .
 COPY favicon.ico .
 
 # Install app dependencies
 ENV NPM_CONFIG_LOGLEVEL warn
-RUN npm ci --production
+ENV NODE_ENV production
+RUN npm ci
 
 # Expose the listening port of your app
 EXPOSE 1337
@@ -38,4 +35,4 @@ EXPOSE 1337
 # [debugging] Show current folder structure in logs
 # RUN pwd && ls -al
 
-CMD [ "pm2-runtime", "start", "ecosystem.prod.config.js" ]
+CMD [ "node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@
 
 A quick description of strapi-skeleton.
 
+[TODO] table of contents
+
 ## no-docker
 
 ### install
 
 ```bash
 npm install
-npm install -g pm2
 ```
 
 ### run
@@ -40,7 +41,13 @@ export DATABASE_PASSWORD=strapi-user-alright
 ```
 
 ```bash
-pm2 start ecosystem.config.js
+npm start
+```
+
+aka
+
+```bash
+node server.js
 ```
 
 #### view strapi app
@@ -52,9 +59,25 @@ localhost:1337/admin
 
 #### teardown
 
+`ctrl+c` to kill node process
+
+[TODO] other ways to kill node/ways that node might need to be killed, e.g. if daemonized/running in background
+
 ```bash
-pm2 stop strapi-skeleton-dev
 brew services stop postgresql
+```
+
+#### [advanced] using pm2 as a process manager
+
+[TODO] add motivation and caveats around using pm2 (or another process manager like forever.js) to run the application;
+especially as it relates to official guidance against running applications via process managers in docker containers.
+
+[TODO] `ecosystem.config.js` vs `ecosystem.prod.config.js`
+
+```bash
+npm install -g pm2
+pm2 start ecosystem.config.js
+pm2 stop strapi-skeleton-dev
 pm2 kill
 ```
 
@@ -87,8 +110,6 @@ docker run --name postgres-ok \
 
 ##### optional: run canonical/other postgres container
 
-###### get image and run
-
 ```bash
 docker pull postgres
 ```
@@ -99,8 +120,6 @@ docker run --name postgres-ok \
   -e POSTGRES_PASSWORD=pg-user-alright \
   -d postgres
 ```
-
-###### psql to configure postgres db for strapi
 
 ```bash
 docker run -it \
@@ -140,16 +159,8 @@ docker run -d \
 #### view strapi application logs in container
 
 ```bash
-docker exec -it strapi-ok pm2 log
+docker logs strapi-ok
 ```
-
-```bash
-docker exec -it strapi-ok pm2 monit
-docker exec -it strapi-ok \
-  pm2 restart ecosystem.prod.config.js --update-env
-```
-
-`--update-env` is optional and [reloads pm2 config](https://pm2.io/doc/en/runtime/guide/ecosystem-file/#updating-the-environment) in `ecosystem.config.js`
 
 #### view docker strapi app
 
@@ -167,6 +178,7 @@ docker container prune
 docker network rm bridge strapi-db-bridge
 docker network prune
 docker image rm strapi
+docker image rm strapi-postgres
 docker image prune
 ```
 
@@ -179,11 +191,3 @@ docker image prune
 `Dockerfile` image is more or less production-ready.
 
 [TODO] Caveats.
-
-<!-- ## misc
-```bash
-docker exec -it some-strapi pm2 log
-docker exec -it some-strapi pm2 ls
-docker exec -it some-strapi pm2 monit
-```
--->

--- a/docker-api/Dockerfile
+++ b/docker-api/Dockerfile
@@ -11,9 +11,6 @@ FROM node:lts-alpine
 # and without this unsafe-perm fix, heroku builds are failing
 RUN npm config set unsafe-perm true
 
-# Install pm2
-RUN npm install pm2 -g
-
 WORKDIR /app/strapi-skeleton
 
 # Bundle APP files
@@ -23,12 +20,12 @@ COPY public public/
 COPY package.json .
 COPY package-lock.json .
 COPY server.js .
-COPY ecosystem.prod.config.js .
 COPY favicon.ico .
 
 # Install app dependencies
 ENV NPM_CONFIG_LOGLEVEL warn
-RUN npm ci --production
+ENV NODE_ENV production
+RUN npm ci
 
 # Expose the listening port of your app
 EXPOSE 1337
@@ -36,4 +33,4 @@ EXPOSE 1337
 # [debugging] Show current folder structure in logs
 # RUN ls -al -R
 
-CMD [ "pm2-runtime", "start", "ecosystem.prod.config.js" ]
+CMD [ "node", "server.js"]

--- a/docker-api/README.md
+++ b/docker-api/README.md
@@ -8,6 +8,8 @@ this is desirable both for space savings (>40%) and reduced complexity of fewer 
 
 ## build api-only image
 
+from project root
+
 ```bash
 docker build --file docker-api/Dockerfile -t strapi-api .
 ```
@@ -20,5 +22,13 @@ i.e. running `docker build` from `docker-api/` will create path problems.
 ## run api-only container
 
 ```bash
-docker run -d -p 1337:1337 --net strapi-db-bridge --name strapi-api-ok strapi-api
+docker run -d \
+  -p 1337:1337 \
+  --net strapi-db-bridge \
+  --name strapi-api-ok \
+  -e DATABASE_HOST=postgres-ok \
+  -e DATABASE_NAME=strapi-db \
+  -e DATABASE_USERNAME=strapi-user \
+  -e DATABASE_PASSWORD=strapi-user-alright \
+  strapi-api
 ```


### PR DESCRIPTION
remove pm2 from docker images per google cloud best practices: https://cloud.google.com/solutions/best-practices-for-building-containers#package_a_single_app_per_container

> You might see the following actions in public images, but do not follow their example:
> + Using a process management system such as supervisord to manage one or several apps in the container."

aside from a violation of best practices, removing pm2 decreases image build time as well as the resulting image's size which is great

leaving pm2 ecosystem config files and instructions for running with pm2 in readme; there are (1) sometimes legitimate reasons to deviate from best practices and (2) other contexts where a process manager would be a good idea, i.e. running the app on a host without containerization