### PR TITLE
feat: optimize for docker build cache

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,3 @@
-*/node_modules
+*/**/node_modules
 .vscode
 .git

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,21 +13,24 @@ RUN npm config set unsafe-perm true
 
 WORKDIR /app/strapi-skeleton
 
-# Bundle APP files
-COPY admin admin/
-COPY api api/
-COPY config config/
-COPY plugins plugins/
-COPY public public/
+# necessary for `npm install`
 COPY package.json .
 COPY package-lock.json .
-COPY server.js .
-COPY favicon.ico .
+# necessary for postinstall script
+COPY admin admin/
+COPY plugins plugins/
 
 # Install app dependencies
 ENV NPM_CONFIG_LOGLEVEL warn
 ENV NODE_ENV production
 RUN npm ci
+
+# Bundle APP files
+COPY favicon.ico .
+COPY public public/
+COPY config config/
+COPY server.js .
+COPY api api/
 
 # Expose the listening port of your app
 EXPOSE 1337

--- a/docker-api/Dockerfile
+++ b/docker-api/Dockerfile
@@ -13,19 +13,20 @@ RUN npm config set unsafe-perm true
 
 WORKDIR /app/strapi-skeleton
 
-# Bundle APP files
-COPY api api/
-COPY config config/
-COPY public public/
 COPY package.json .
 COPY package-lock.json .
-COPY server.js .
-COPY favicon.ico .
 
 # Install app dependencies
 ENV NPM_CONFIG_LOGLEVEL warn
 ENV NODE_ENV production
 RUN npm ci
+
+# Bundle APP files
+COPY favicon.ico .
+COPY public public/
+COPY config config/
+COPY server.js .
+COPY api api/
 
 # Expose the listening port of your app
 EXPOSE 1337


### PR DESCRIPTION
build steps whose artifacts change less frequently should be performed earlier in the dockerfile where possible, as the docker engine will only leverage the build cache for a given step if the prior step did;

every additional contiguous, unchanged layer at the beginning of the dockerfile translate to another opportunity to draw upon the cache in subsequent builds

here, we want to perform the npm installation early in the build, before copying anything else because the resulting `node_modules` folder is (1) large and (2) likely less frequently modified than the app source files; however, we have to copy `/admin` and `/plugins` before the install because there is a `postinstall` script which looks for those directories to install their dependencies

it's especially important that this happens correctly since we're also updating the `.dockerignore` in this pull to correctly exclude all `node_modules` directories from the build context